### PR TITLE
回避光标颜色是黑色的情形

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -319,8 +319,6 @@ DIFF-MIN: 坐标差值最小值，小于这个值就不显示动画，可以排�
 
 ```lisp
 ;;; -*- lexical-binding: t; -*-
-;;; 开启光标残影.
-;;; 下载 DLL: <https://github.com/lynnux/pop-select>.
 
 (require 'cl-lib)
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -313,9 +313,24 @@ DIFF-MIN: 坐标差值最小值，小于这个值就不显示动画，可以排�
            )))))
   (add-hook 'post-command-hook 'show-cursor-animation))
 ```
-更复杂的配置：
+
+<details>
+  <summary>根据背景色调整光标的残影的颜色</summary>
+
 ```lisp
 ;;; -*- lexical-binding: t; -*-
+;;; 开启光标残影.
+;;; 下载 DLL: <https://github.com/lynnux/pop-select>.
+
+(require 'cl-lib)
+
+(when (and (eq system-type 'windows-nt)
+           (or (display-graphic-p)
+               (daemonp)))
+  (ignore-error 'file-missing
+    ;; 把 DLL 加到 `load-path' 里.
+    (load-library "pop_select.dll")))
+
 (with-eval-after-load "pop_select.dll"
   (let ((cursor-animation-color-R 0)
         (cursor-animation-color-G 0)
@@ -325,53 +340,59 @@ DIFF-MIN: 坐标差值最小值，小于这个值就不显示动画，可以排�
               (lambda (_window _position)
                 "滚屏时关闭残影: 1. 节约性能; 2. 设置 `scroll-margin' 后, 滚屏时残影位置不准确."
                 (setq cursor-animation? nil)))
-    (defun show-cursor-animation ()
-      (when-let ((window-absolute-pixel-position
-                  (when (or cursor-animation?
-                            (eq this-command 'recenter-top-bottom))
-                    (window-absolute-pixel-position))))
-        (let ((line-pixel-height (line-pixel-height)))
-          (pop-select/beacon-animation
-           (car window-absolute-pixel-position) (if header-line-format
-                                                    ;; 修复开启 `header-line-format' 时 y 值不正确.
-                                                    (- (cdr window-absolute-pixel-position)
-                                                       line-pixel-height)
-                                                  (cdr window-absolute-pixel-position))
-           (if (eq cursor-type 'bar)
-               1
-             (if-let ((glyph (let ((point (point)))
-                               (when (< point (point-max))
-                                 (aref (font-get-glyphs (font-at point)
-                                                        point (1+ point)) 0)))))
-                 (aref glyph 4)
-               (window-font-width))) line-pixel-height
-           140 60
-           cursor-animation-color-R cursor-animation-color-G cursor-animation-color-B
-           ;; 排除大约是单个半角字符的距离:
-           24)))
-      (setq cursor-animation? t))
-    (add-hook 'post-command-hook #'show-cursor-animation)
+    (add-hook 'post-command-hook
+              (lambda ()
+                (when-let ((window-absolute-pixel-position
+                            (when (or cursor-animation?
+                                      (eq this-command 'recenter-top-bottom))
+                              (window-absolute-pixel-position))))
+                  (let ((line-pixel-height (line-pixel-height)))
+                    (pop-select/beacon-animation
+                     (car window-absolute-pixel-position) (if header-line-format
+                                                              (- (cdr window-absolute-pixel-position)
+                                                                 line-pixel-height)
+                                                            (cdr window-absolute-pixel-position))
+                     (if (eq cursor-type 'bar)
+                         1
+                       (if-let ((glyph (let ((point (point)))
+                                         (when (< point (point-max))
+                                           (aref (font-get-glyphs (font-at point)
+                                                                  point (1+ point)) 0)))))
+                           (aref glyph 4)
+                         (window-font-width))) line-pixel-height
+                     180 100
+                     cursor-animation-color-R cursor-animation-color-G cursor-animation-color-B
+                     ;; 排除大约是单个半角字符的距离:
+                     24)))
+                (setq cursor-animation? t)))
     (letrec ((cursor-animation-color-setter
               (lambda ()
                 (remove-hook 'server-after-make-frame-hook cursor-animation-color-setter)
                 (let ((cursor-animation-color-RGB
-                       ;; 如果背景色是暗的, 就将残影设为光标颜色的暗度+50%;
-                       ;; 反之亦然.
-                       (color-name-to-rgb (funcall (if (color-dark-p (color-name-to-rgb (face-background 'default)))
-                                                       #'color-darken-name
-                                                     #'color-lighten-name)
-                                                   (face-background 'cursor) 50))))
-                  (setq cursor-animation-color-R (floor (* (cl-first  cursor-animation-color-RGB) 255.9999999999999))
-                        cursor-animation-color-G (floor (* (cl-second cursor-animation-color-RGB) 255.9999999999999))
-                        cursor-animation-color-B (floor (* (cl-third  cursor-animation-color-RGB) 255.9999999999999)))))))
+                       (cl-mapcar (let* ((ratio 0.5)  ; 只需要修改此值.
+                                         (1-ratio (- 1 ratio)))
+                                    (lambda (cursor-color default-color)
+                                      "按照 ratio:(1-ratio) 的比例混合光标颜色和背景色."
+                                      (floor (* (+ (*   ratio  cursor-color)
+                                                   (* 1-ratio default-color))
+                                                255.9999999999999))))
+                                  (color-name-to-rgb (face-background 'cursor))
+                                  (color-name-to-rgb (face-background 'default)))))
+                  (setq cursor-animation-color-R (cl-first  cursor-animation-color-RGB)
+                        cursor-animation-color-G (cl-second cursor-animation-color-RGB)
+                        cursor-animation-color-B (cl-third  cursor-animation-color-RGB))))))
       ;; 如果是 daemon, 则必须等到第一个 visible frame 创建之后再设置残影的颜色.
       (add-hook 'server-after-make-frame-hook cursor-animation-color-setter)
       (unless (daemonp)
         ;; 如果不是 daemon, 确保大部分有关 face 的设置生效后再设置残影的颜色.
-        (add-hook 'emacs-startup-hook
-                  cursor-animation-color-setter
-                  90)))))
+        (add-hook 'emacs-startup-hook cursor-animation-color-setter 90))
+      (when (eq this-command 'eval-buffer)
+        ;; 若要测试本文件, 直接将其拷贝到单独的 buffer, 然后执行 `eval-buffer'.
+        (funcall cursor-animation-color-setter)))))
 ```
+
+</details>
+
 效果图：
 
 ![gif](gif/ani.gif)


### PR DESCRIPTION
之前那段代码, 如果光标颜色是黑色的, 调用 `color-lighten-name` 之后还是黑色 (0, 0, 0) 的, 所以看不见残影.
现在把颜色的设置方案改成了按照比例 (比例可以自行设置, 见代码段中的

```
(cl-mapcar (let* ((ratio 0.5)  ; 只需要修改此值.
```

这一行) 混合光标颜色和背景色.
除非某个使用者很逆天, 把光标颜色和背景色都设置成了黑色 (或者其中一种是黑色, 另一种接近黑色), 按照这次混合颜色的方案, 是不会出现黑色的.

___

新的代码段默认折叠了, 节约 ReadMe 的篇幅.

<details>
  <summary>就像这样</summary>

```lisp
;;; -*- lexical-binding: t; -*-

(require 'cl-lib)

(when (and (eq system-type 'windows-nt)
           (or (display-graphic-p)
               (daemonp)))
  (ignore-error 'file-missing
    ;; 把 DLL 加到 `load-path' 里.
    (load-library "pop_select.dll")))

(with-eval-after-load "pop_select.dll"
  (let ((cursor-animation-color-R 0)
        (cursor-animation-color-G 0)
        (cursor-animation-color-B 0)
        cursor-animation?)  ; 是否开启光标残影.
    (add-hook 'window-scroll-functions
              (lambda (_window _position)
                "滚屏时关闭残影: 1. 节约性能; 2. 设置 `scroll-margin' 后, 滚屏时残影位置不准确."
                (setq cursor-animation? nil)))
    (add-hook 'post-command-hook
              (lambda ()
                (when-let ((window-absolute-pixel-position
                            (when (or cursor-animation?
                                      (eq this-command 'recenter-top-bottom))
                              (window-absolute-pixel-position))))
                  (let ((line-pixel-height (line-pixel-height)))
                    (pop-select/beacon-animation
                     (car window-absolute-pixel-position) (if header-line-format
                                                              (- (cdr window-absolute-pixel-position)
                                                                 line-pixel-height)
                                                            (cdr window-absolute-pixel-position))
                     (if (eq cursor-type 'bar)
                         1
                       (if-let ((glyph (let ((point (point)))
                                         (when (< point (point-max))
                                           (aref (font-get-glyphs (font-at point)
                                                                  point (1+ point)) 0)))))
                           (aref glyph 4)
                         (window-font-width))) line-pixel-height
                     180 100
                     cursor-animation-color-R cursor-animation-color-G cursor-animation-color-B
                     ;; 排除大约是单个半角字符的距离:
                     24)))
                (setq cursor-animation? t)))
    (letrec ((cursor-animation-color-setter
              (lambda ()
                (remove-hook 'server-after-make-frame-hook cursor-animation-color-setter)
                (let ((cursor-animation-color-RGB
                       (cl-mapcar (let* ((ratio 0.5)  ; 只需要修改此值.
                                         (1-ratio (- 1 ratio)))
                                    (lambda (cursor-color default-color)
                                      "按照 ratio:(1-ratio) 的比例混合光标颜色和背景色."
                                      (floor (* (+ (*   ratio  cursor-color)
                                                   (* 1-ratio default-color))
                                                255.9999999999999))))
                                  (color-name-to-rgb (face-background 'cursor))
                                  (color-name-to-rgb (face-background 'default)))))
                  (setq cursor-animation-color-R (cl-first  cursor-animation-color-RGB)
                        cursor-animation-color-G (cl-second cursor-animation-color-RGB)
                        cursor-animation-color-B (cl-third  cursor-animation-color-RGB))))))
      ;; 如果是 daemon, 则必须等到第一个 visible frame 创建之后再设置残影的颜色.
      (add-hook 'server-after-make-frame-hook cursor-animation-color-setter)
      (unless (daemonp)
        ;; 如果不是 daemon, 确保大部分有关 face 的设置生效后再设置残影的颜色.
        (add-hook 'emacs-startup-hook cursor-animation-color-setter 90))
      (when (eq this-command 'eval-buffer)
        ;; 若要测试本文件, 直接将其拷贝到单独的 buffer, 然后执行 `eval-buffer'.
        (funcall cursor-animation-color-setter)))))
```

</details>

___

测试: 直接 `runemacs.exe -q` (假设 DLL 在 site-lisp 中) 启动, 然后把代码段粘贴到 `*scratch*`, 因为其中有一段

```
(when (eq this-command 'eval-buffer)
  ;; 若要测试本文件, 直接将其拷贝到单独的 buffer, 然后执行 `eval-buffer'.
  (funcall cursor-animation-color-setter)))))
```

所以直接 `eval-buffer` 就好了.

如果测试有问题就先不要合并.